### PR TITLE
Check clientCertFile and caCertFile using string.IsNullOrEmpty

### DIFF
--- a/DriverSparkplugB/DriverSparkplugB.cs
+++ b/DriverSparkplugB/DriverSparkplugB.cs
@@ -292,7 +292,7 @@ namespace DriverSparkplugB
                 }
                 else
                 {
-					if (c.caCertFile == "")
+					if (string.IsNullOrEmpty(c.caCertFile))
 					{
 						client = new MqttClient(c.hostname, c.portnumber, true, (MqttSslProtocols)c.security, null, null);
 					}
@@ -311,7 +311,7 @@ namespace DriverSparkplugB
 						}
 						try
 						{
-							if (c.clientCertFile == null)
+							if (!string.IsNullOrEmpty(c.clientCertFile))
 							{
 								if (c.clientCertFormat == 0) // DER
 								{


### PR DESCRIPTION
This fixes a bug causing the clientCertFile to not be used when it should be for TLS/SSL connections.

The fix is to use:
`(!string.IsNullOrEmpty(c.clientCertFile))`

instead of:
`(c.clientCertFile == null)`

when checking whether to include the client certificate.